### PR TITLE
[LP#1999427] retry install-upgrade hook when ManifestClientError occurs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
   charmcraft-build:
     name: Build Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -38,6 +38,12 @@ jobs:
           sudo lxc network set lxdbr0 ipv6.address none
           sudo usermod -a -G lxd $USER
           sg lxd -c 'lxc version'
+      - name: Remove Docker
+        run: |
+          # https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23
+          sudo rm -rf /etc/docker
+          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
+          sudo iptables -P FORWARD ACCEPT
       - name: Install Charmcraft
         run: |
           sudo snap install charmcraft --classic --channel=latest/stable

--- a/actions.yaml
+++ b/actions.yaml
@@ -26,3 +26,20 @@ scrub-resources:
       default: ""
       description: |
         Space separated list of kubernetes resource types to filter scrubbing   
+sync-resources:
+  description: |
+    Add kubernetes resources which should be created by this charm which aren't
+    present within the cluster.
+  params:
+    controller:
+      type: string
+      default: ""
+      description: |
+        Filter list based on "storage" manifests.
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types
+        to use a filter during the sync. This helps limit
+        which missing resources are applied.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 pydantic
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@602eb96dcfa54269505923b28d861771879c703d
+git+https://github.com/canonical/ops-lib-manifest.git@0929a0d1483b927783c75cdc5ebe6694b7f26d88
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,7 +87,11 @@ class GcpK8sStorageCharm(CharmBase):
     def _sync_resources(self, event):
         manifests = event.params.get("controller", "")
         resources = event.params.get("resources", "")
-        return self.collector.apply_missing_resources(event, manifests, resources)
+        try:
+            self.collector.apply_missing_resources(event, manifests, resources)
+        except ManifestClientError:
+            msg = "Failed to apply missing resources. API Server unavailable."
+            event.set_results({"result": msg})
 
     def _request_gcp_features(self, event):
         self.integrator.enable_block_storage_management()
@@ -207,7 +211,12 @@ class GcpK8sStorageCharm(CharmBase):
         if self.stored.config_hash:
             self.unit.status = MaintenanceStatus("Cleaning up GCP Storage")
             for controller in self.collector.manifests.values():
-                controller.delete_manifests(ignore_unauthorized=True)
+                try:
+                    controller.delete_manifests(ignore_unauthorized=True)
+                except ManifestClientError:
+                    self.unit.status = WaitingStatus("Waiting for kube-apiserver")
+                    event.defer()
+                    return
         self.unit.status = MaintenanceStatus("Shutting down")
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -203,11 +203,12 @@ class GcpK8sStorageCharm(CharmBase):
             try:
                 controller.apply_manifests()
             except ManifestClientError:
+                self.unit.status = WaitingStatus("Waiting for kube-apiserver")
                 event.defer()
                 return
         self.stored.deployed = True
 
-    def _cleanup(self, _event):
+    def _cleanup(self, event):
         if self.stored.config_hash:
             self.unit.status = MaintenanceStatus("Cleaning up GCP Storage")
             for controller in self.collector.manifests.values():

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/ICON.svg \
       --skip {[vars]cov_path} \


### PR DESCRIPTION
[LP#1999427](https://bugs.launchpad.net/bugs/1999427)

* adding sync-resource action which was inexplicably missing
* use 1.0.0 version of ops-lib-manifest