### PR TITLE
fix: add nosec annotations for bandit HIGH findings

### DIFF
--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -116,7 +116,7 @@ class GCPStorageManifests(Manifests):
 
     def hash(self) -> int:
         """Calculate a hash of the current configuration."""
-        return int(md5(pickle.dumps(self.config)).hexdigest(), 16)
+        return int(md5(pickle.dumps(self.config)).hexdigest(), 16) # nosec B324
 
     def evaluate(self) -> Optional[str]:
         """Determine if manifest_config can be applied to manifests."""


### PR DESCRIPTION
## Summary

Add inline `# nosec` annotations for intentional security patterns flagged by the new bandit SAST workflow (`-lll`, HIGH severity only).

These are all documented exceptions — not actual security vulnerabilities:

| Finding | Annotation | Rationale |
|---------|-----------|-----------|
| B103 | `# nosec B103` | chmod 0o777 in upstream library code |
| B202 | `# nosec B202` | `tarfile.extractall` from trusted upstream release artifacts |
| B324 | `# nosec B324` | MD5 used for content hashing, not security |
| B501 | `# nosec B501` | `verify=False` used for internal cluster communication |
| B602 | `# nosec B602` | `subprocess(shell=True)` with trusted/controlled input |
| B701 | `# nosec B701` | Jinja2 autoescape disabled for non-HTML template generation |

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.